### PR TITLE
Refactor: 将gui/pageFileTree.go 和 utils/kvtree/lib.go，sort.go 重构为非递归

### DIFF
--- a/utils/jsonutils/sort.go
+++ b/utils/jsonutils/sort.go
@@ -3,7 +3,6 @@ package jsonutils
 import (
 	"encoding/json"
 	"sort"
-
 	// "github.com/bytedance/sonic"
 )
 
@@ -25,30 +24,103 @@ func SortJSON(jsonStr string) (string, error) {
 	return string(sortedJSON), nil
 }
 
-// sortMapKeys 递归地对 map 的键进行排序
+// sortMapKeys 非递归地对 map 的键进行排序
 func sortMapKeys(data interface{}) interface{} {
-	switch v := data.(type) {
-	case map[string]interface{}:
-		// 对 map 的键进行排序
-		keys := make([]string, 0, len(v))
-		for k := range v {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-
-		sortedMap := make(map[string]interface{})
-		for _, k := range keys {
-			sortedMap[k] = sortMapKeys(v[k])
-		}
-		return sortedMap
-	case []interface{}:
-		// 对 slice 进行递归处理
-		for i, item := range v {
-			v[i] = sortMapKeys(item)
-		}
-		return v
-	default:
-		// 其他类型直接返回
-		return v
+	type queueItem struct {
+		key    string
+		value  interface{}
+		parent interface{}
+		index  int
 	}
+
+	// 初始化队列，将根元素入队
+	queue := []queueItem{{key: "", value: data, parent: nil, index: -1}}
+	var result interface{}
+
+	for len(queue) > 0 {
+		// 取出队列的第一个元素
+		current := queue[0]
+		queue = queue[1:]
+
+		switch v := current.value.(type) {
+		case map[string]interface{}:
+			// 对 map 的键进行排序
+			keys := make([]string, 0, len(v))
+			for k := range v {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+
+			sortedMap := make(map[string]interface{})
+			for _, k := range keys {
+				sortedMap[k] = v[k]
+				// 将 map 中的子元素加入队列
+				queue = append(queue, queueItem{key: k, value: v[k], parent: sortedMap})
+			}
+
+			if current.parent == nil {
+				// 如果没有父级，这是最顶层的 map，保存为结果
+				result = sortedMap
+			} else if pMap, ok := current.parent.(map[string]interface{}); ok {
+				// 将排序后的 map 赋值回父 map
+				pMap[current.key] = sortedMap
+			} else if pSlice, ok := current.parent.([]interface{}); ok {
+				// 将排序后的 map 赋值回父 slice
+				pSlice[current.index] = sortedMap
+			}
+
+		case []interface{}:
+			// 对 slice 进行非递归处理，将子元素加入队列
+			for i := 0; i < len(v); i++ { // 正序入队，保持顺序
+				queue = append(queue, queueItem{value: v[i], parent: v, index: i})
+			}
+
+			if current.parent == nil {
+				// 如果没有父级，这是最顶层的 slice，保存为结果
+				result = v
+			}
+
+		default:
+			if current.parent == nil {
+				// 如果没有父级，这是最顶层的值，保存为结果
+				result = v
+			} else if pMap, ok := current.parent.(map[string]interface{}); ok {
+				// 将值赋回父 map
+				pMap[current.key] = v
+			} else if pSlice, ok := current.parent.([]interface{}); ok {
+				// 将值赋回父 slice
+				pSlice[current.index] = v
+			}
+		}
+	}
+
+	return result
 }
+
+//func sortMapKeys(data interface{}) interface{} {
+//		switch v := data.(type) {
+//		case map[string]interface{}:
+//			// 对 map 的键进行排序
+//			keys := make([]string, 0, len(v))
+//			for k := range v {
+//				keys = append(keys, k)
+//			}
+//			sort.Strings(keys)
+//
+//			sortedMap := make(map[string]interface{})
+//			for _, k := range keys {
+//				sortedMap[k] = sortMapKeys(v[k])
+//			}
+//			return sortedMap
+//		case []interface{}:
+//			// 对 slice 进行递归处理
+//			for i, item := range v {
+//				v[i] = sortMapKeys(item)
+//			}
+//			return v
+//		default:
+//			// 其他类型直接返回
+//			return v
+//		}
+//	}
+//}

--- a/utils/kvtree/lib.go
+++ b/utils/kvtree/lib.go
@@ -29,88 +29,180 @@ type KV_Tree struct {
 	DisNodeList []*KV_Node
 }
 
+// 将json数据转换为KV树 非递归
 func (tree *KV_Tree) jsonToKVNode(data interface{}, key string, parent *KV_Node) *KV_Node {
 	node := &KV_Node{
 		Key:      key,
 		Value:    data,
-		IsExpand: false,
+		IsExpand: key == "root",
 		Parent:   parent,
 	}
 
-	if key == "root" {
-		node.IsExpand = true
+	queue := []struct {
+		data   interface{}
+		node   *KV_Node
+		parent *KV_Node
+	}{
+		{data, node, parent},
 	}
 
-	switch value := data.(type) {
-	case map[string]interface{}:
-		var lastChild *KV_Node
+	for len(queue) > 0 {
+		current := queue[len(queue)-1]
+		queue = queue[:len(queue)-1]
 
-		// Sort keys to ensure consistent order
-		keys := make([]string, 0, len(value))
-		for k := range value {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
+		currentNode := current.node
+		currentData := current.data
 
-		for _, k := range keys {
-			child := tree.jsonToKVNode(value[k], k, node)
-			if node.Child == nil {
-				node.Child = child
-			} else {
-				lastChild.Next = child
+		switch value := currentData.(type) {
+		case map[string]interface{}:
+			var lastChild *KV_Node
+
+			// 对键进行排序以确保顺序一致
+			keys := make([]string, 0, len(value))
+			for k := range value {
+				keys = append(keys, k)
 			}
-			lastChild = child
-		}
-	case []interface{}:
-		var lastChild *KV_Node
-		for i, v := range value {
-			child := tree.jsonToKVNode(v, fmt.Sprintf("[%d]", i), node)
-			if node.Child == nil {
-				node.Child = child
-			} else {
-				lastChild.Next = child
+			sort.Strings(keys)
+
+			for _, k := range keys {
+				childNode := &KV_Node{
+					Key:      k,
+					Value:    value[k],
+					IsExpand: false,
+					Parent:   currentNode,
+				}
+
+				if currentNode.Child == nil {
+					currentNode.Child = childNode
+				} else {
+					lastChild.Next = childNode
+				}
+				lastChild = childNode
+
+				queue = append(queue, struct {
+					data   interface{}
+					node   *KV_Node
+					parent *KV_Node
+				}{value[k], childNode, currentNode})
 			}
-			lastChild = child
+
+		case []interface{}:
+			var lastChild *KV_Node
+			for i, v := range value {
+				childNode := &KV_Node{
+					Key:      fmt.Sprintf("[%d]", i),
+					Value:    v,
+					IsExpand: false,
+					Parent:   currentNode,
+				}
+
+				if currentNode.Child == nil {
+					currentNode.Child = childNode
+				} else {
+					lastChild.Next = childNode
+				}
+				lastChild = childNode
+
+				queue = append(queue, struct {
+					data   interface{}
+					node   *KV_Node
+					parent *KV_Node
+				}{v, childNode, currentNode})
+			}
 		}
 	}
 
 	return node
 }
 
-// 更新父节点
+// 递归
+//func (tree *KV_Tree) jsonToKVNode(data interface{}, key string, parent *KV_Node) *KV_Node {
+//	node := &KV_Node{
+//		Key:      key,
+//		Value:    data,
+//		IsExpand: false,
+//		Parent:   parent,
+//	}
+//
+//	if key == "root" {
+//		node.IsExpand = true
+//	}
+//
+//	switch value := data.(type) {
+//	case map[string]interface{}:
+//		var lastChild *KV_Node
+//
+//		// Sort keys to ensure consistent order
+//		keys := make([]string, 0, len(value))
+//		for k := range value {
+//			keys = append(keys, k)
+//		}
+//		sort.Strings(keys)
+//
+//		for _, k := range keys {
+//			child := tree.jsonToKVNode(value[k], k, node)
+//			if node.Child == nil {
+//				node.Child = child
+//			} else {
+//				lastChild.Next = child
+//			}
+//			lastChild = child
+//		}
+//	case []interface{}:
+//		var lastChild *KV_Node
+//		for i, v := range value {
+//			child := tree.jsonToKVNode(v, fmt.Sprintf("[%d]", i), node)
+//			if node.Child == nil {
+//				node.Child = child
+//			} else {
+//				lastChild.Next = child
+//			}
+//			lastChild = child
+//		}
+//	}
+//
+//	return node
+//}
+
+// 更新父节点 非递归
 func (tree *KV_Tree) UpdateParentNodes(node *KV_Node) {
-	if node == nil || node.Parent == nil {
-		return
-	}
-	parent := node.Parent
-	switch parent.Value.(type) {
-	case map[string]interface{}:
-		newMap := make(map[string]interface{})
-		for child := parent.Child; child != nil; child = child.Next {
-			newMap[child.Key] = child.Value
+	for node != nil && node.Parent != nil {
+		parent := node.Parent
+		switch parent.Value.(type) {
+		case map[string]interface{}:
+			newMap := make(map[string]interface{})
+			for child := parent.Child; child != nil; child = child.Next {
+				newMap[child.Key] = child.Value
+			}
+			parent.Value = newMap
+		case []interface{}:
+			newSlice := make([]interface{}, 0)
+			for child := parent.Child; child != nil; child = child.Next {
+				newSlice = append(newSlice, child.Value)
+			}
+			parent.Value = newSlice
 		}
-		parent.Value = newMap
-	case []interface{}:
-		newSlice := make([]interface{}, 0)
-		for child := parent.Child; child != nil; child = child.Next {
-			newSlice = append(newSlice, child.Value)
-		}
-		parent.Value = newSlice
+		node = parent
 	}
-	tree.UpdateParentNodes(parent)
 }
 
-// 更新子节点
+// 更新子节点 非递归
 func (tree *KV_Tree) UpdateChildNodes(node *KV_Node) *KV_Node {
 	if node == nil {
 		return nil
 	}
 
-	// 清空原有的子节点
-	node.Child = nil
+	queue := []*KV_Node{node}
+
+	for len(queue) > 0 {
+		currentNode := queue[len(queue)-1]
+		queue = queue[:len(queue)-1]
+
+		// 清空当前节点的子节点
+		currentNode.Child = nil
 
 		// 根据节点的值类型来构建新的子节点链表
-		switch value := node.Value.(type) {
+		switch value := currentNode.Value.(type) {
 		case map[string]interface{}:
 			var lastChild *KV_Node
 			for key, v := range value {
@@ -118,15 +210,14 @@ func (tree *KV_Tree) UpdateChildNodes(node *KV_Node) *KV_Node {
 					Key:   key,
 					Value: v,
 				}
-				if node.Child == nil {
-					node.Child = childNode
+				if currentNode.Child == nil {
+					currentNode.Child = childNode
 				} else {
 					lastChild.Next = childNode
 				}
 				lastChild = childNode
-	
-				// 递归更新子节点的子节点
-				tree.UpdateChildNodes(childNode)
+
+				queue = append(queue, childNode)
 			}
 		case []interface{}:
 			var lastChild *KV_Node
@@ -135,21 +226,96 @@ func (tree *KV_Tree) UpdateChildNodes(node *KV_Node) *KV_Node {
 					Key:   fmt.Sprintf("[%d]", i),
 					Value: v,
 				}
-				if node.Child == nil {
-					node.Child = childNode
+				if currentNode.Child == nil {
+					currentNode.Child = childNode
 				} else {
 					lastChild.Next = childNode
 				}
 				lastChild = childNode
-	
-				// 递归更新子节点的子节点
-				tree.UpdateChildNodes(childNode)
+
+				queue = append(queue, childNode)
 			}
 		}
-	
+	}
 
 	return node
 }
+
+// // 更新父节点 递归
+//
+//	func (tree *KV_Tree) UpdateParentNodes(node *KV_Node) {
+//		if node == nil || node.Parent == nil {
+//			return
+//		}
+//		parent := node.Parent
+//		switch parent.Value.(type) {
+//		case map[string]interface{}:
+//			newMap := make(map[string]interface{})
+//			for child := parent.Child; child != nil; child = child.Next {
+//				newMap[child.Key] = child.Value
+//			}
+//			parent.Value = newMap
+//		case []interface{}:
+//			newSlice := make([]interface{}, 0)
+//			for child := parent.Child; child != nil; child = child.Next {
+//				newSlice = append(newSlice, child.Value)
+//			}
+//			parent.Value = newSlice
+//		}
+//		tree.UpdateParentNodes(parent)
+//	}
+//
+// // 更新子节点 递归
+//
+//	func (tree *KV_Tree) UpdateChildNodes(node *KV_Node) *KV_Node {
+//		if node == nil {
+//			return nil
+//		}
+//
+//		// 清空原有的子节点
+//		node.Child = nil
+//
+//			// 根据节点的值类型来构建新的子节点链表
+//			switch value := node.Value.(type) {
+//			case map[string]interface{}:
+//				var lastChild *KV_Node
+//				for key, v := range value {
+//					childNode := &KV_Node{
+//						Key:   key,
+//						Value: v,
+//					}
+//					if node.Child == nil {
+//						node.Child = childNode
+//					} else {
+//						lastChild.Next = childNode
+//					}
+//					lastChild = childNode
+//
+//					// 递归更新子节点的子节点
+//					tree.UpdateChildNodes(childNode)
+//				}
+//			case []interface{}:
+//				var lastChild *KV_Node
+//				for i, v := range value {
+//					childNode := &KV_Node{
+//						Key:   fmt.Sprintf("[%d]", i),
+//						Value: v,
+//					}
+//					if node.Child == nil {
+//						node.Child = childNode
+//					} else {
+//						lastChild.Next = childNode
+//					}
+//					lastChild = childNode
+//
+//					// 递归更新子节点的子节点
+//					tree.UpdateChildNodes(childNode)
+//				}
+//			}
+//
+//
+//		return node
+//	}
 func (tree *KV_Tree) Load(fileName string, source map[string]interface{}) error {
 	tree.FileName = fileName
 	tree.Source = &source
@@ -158,38 +324,88 @@ func (tree *KV_Tree) Load(fileName string, source map[string]interface{}) error 
 	return nil
 }
 
-func (tree *KV_Tree) printKVNode(node *KV_Node, indent string, isLast bool) {
-	if node == nil {
-		return
+// 打印KVNode 非递归
+func (tree *KV_Tree) printKVNode(root *KV_Node, indent string, isLast bool) {
+	type nodeState struct {
+		node   *KV_Node
+		indent string
+		isLast bool
 	}
 
-	prefix := TreeSignUpMiddle
-	if isLast {
-		prefix = TreeSignUpEnding
-	}
+	// 初始化栈，将根节点入队列
+	queue := []nodeState{{root, indent, isLast}}
 
-	key := node.Key
-	fmt.Printf("%s%s%s %s\n", indent, prefix, TreeSignDash, key)
-	tree.DisNodeList = append(tree.DisNodeList, node)
+	for len(queue) > 0 {
+		// 弹出队列
+		current := queue[len(queue)-1]
+		queue = queue[:len(queue)-1]
 
-	newIndent := indent
-	if !isLast {
-		newIndent += TreeSignVertical + " "
-	} else {
-		newIndent += " "
-	}
+		if current.node == nil {
+			continue
+		}
 
-	if node.IsExpand {
-		if node.Child != nil {
-			tree.printKVNode(node.Child, newIndent, node.Child.Next == nil)
+		// 构建前缀
+		prefix := TreeSignUpMiddle
+		if current.isLast {
+			prefix = TreeSignUpEnding
+		}
+
+		// 输出当前节点信息
+		key := current.node.Key
+		fmt.Printf("%s%s%s %s\n", current.indent, prefix, TreeSignDash, key)
+		tree.DisNodeList = append(tree.DisNodeList, current.node)
+
+		// 计算新的缩进
+		newIndent := current.indent
+		if !current.isLast {
+			newIndent += TreeSignVertical + " "
+		} else {
+			newIndent += " "
+		}
+
+		// 先处理兄弟节点（Next），再处理子节点（Child）
+		if current.node.Next != nil {
+			queue = append(queue, nodeState{current.node.Next, current.indent, current.node.Next.Next == nil})
+		}
+
+		if current.node.IsExpand && current.node.Child != nil {
+			queue = append(queue, nodeState{current.node.Child, newIndent, current.node.Child.Next == nil})
 		}
 	}
-
-	if node.Next != nil {
-		tree.printKVNode(node.Next, indent, node.Next.Next == nil)
-	}
 }
-func (tree *KV_Tree)Save() error {
-	err:=jsonutils.Write(tree.FileName, tree.NodeList.Value)
+
+//	func (tree *KV_Tree) printKVNode(node *KV_Node, indent string, isLast bool) {
+//		if node == nil {
+//			return
+//		}
+//
+//		prefix := TreeSignUpMiddle
+//		if isLast {
+//			prefix = TreeSignUpEnding
+//		}
+//
+//		key := node.Key
+//		fmt.Printf("%s%s%s %s\n", indent, prefix, TreeSignDash, key)
+//		tree.DisNodeList = append(tree.DisNodeList, node)
+//
+//		newIndent := indent
+//		if !isLast {
+//			newIndent += TreeSignVertical + " "
+//		} else {
+//			newIndent += " "
+//		}
+//
+//		if node.IsExpand {
+//			if node.Child != nil {
+//				tree.printKVNode(node.Child, newIndent, node.Child.Next == nil)
+//			}
+//		}
+//
+//		if node.Next != nil {
+//			tree.printKVNode(node.Next, indent, node.Next.Next == nil)
+//		}
+//	}
+func (tree *KV_Tree) Save() error {
+	err := jsonutils.Write(tree.FileName, tree.NodeList.Value)
 	return err
 }


### PR DESCRIPTION
将 gui/pageFileTree.go 和 utils/kvtree/lib.go,sort.go 中的递归函数重构为基于队列的非递归实现。